### PR TITLE
Fix type of payload in sig_structure of cose_sign1

### DIFF
--- a/lib/src/cose_objects.dart
+++ b/lib/src/cose_objects.dart
@@ -446,11 +446,15 @@ class CoseSign1 {
   /// Generates the intermediate data over which the signature is computed
   String generateIntermediate({dynamic externalPayload}) {
     var protectedEnc = protectedEncoded ?? protected.toEncodedCbor();
+    externalPayload ??= payload;
+    if(externalPayload is! CborBytes) {
+      externalPayload = CborBytes(externalPayload);
+    }
     var data = [
       'Signature1',
       CborBytes(protectedEnc),
       CborBytes([]),
-      externalPayload != null ? CborBytes(externalPayload) : CborBytes(payload)
+      externalPayload,
     ];
     return hex.encode(Uint8List.fromList(cborEncode(CborValue(data))));
   }

--- a/lib/src/cose_objects.dart
+++ b/lib/src/cose_objects.dart
@@ -450,7 +450,7 @@ class CoseSign1 {
       'Signature1',
       CborBytes(protectedEnc),
       CborBytes([]),
-      externalPayload ?? payload
+      externalPayload != null ? CborBytes(externalPayload) : CborBytes(payload)
     ];
     return hex.encode(Uint8List.fromList(cborEncode(CborValue(data))));
   }


### PR DESCRIPTION
In `CoseSign1` class, the `payload` (or `externalPayload`) of signature structure in `generateIntermediate` function should be a `CborBytes`, as specified in the RFC.