### PR TITLE
fix: add driving privileges codes

### DIFF
--- a/lib/src/documents.dart
+++ b/lib/src/documents.dart
@@ -580,6 +580,7 @@ class DrivingPrivilege {
     return DrivingPrivilege(
         vehicleCategoryCode: vehicleCategoryCode,
         issueDate: issueDate,
+        codes: codes,
         expiryDate: expiryDate);
   }
 


### PR DESCRIPTION
It's missing to add `codes` in the `DrivingPrivileges` constructor after building up the list.

As a result, `codes` are always `null` regardless the CBOR data.

This PR fixes the issue by just assigning the `codes` variable to the `DrivingPrivileges` object.